### PR TITLE
Implement basic voxel HRF estimation

### DIFF
--- a/R/voxel_hrf.R
+++ b/R/voxel_hrf.R
@@ -58,8 +58,10 @@ estimate_voxel_hrf <- function(Y, events, basis, nuisance_regs = NULL) {
 
   coef_mat <- estimate_hrf_cpp(X_full, Y)
 
+  coef_basis <- coef_mat[seq_len(ncol(X_basis)), , drop = FALSE]
+
   result <- list(
-    coefficients = coef_mat,
+    coefficients = coef_basis,
     basis = basis,
     conditions = unique(as.character(events$condition))
   )

--- a/src/voxel_hrf.cpp
+++ b/src/voxel_hrf.cpp
@@ -1,11 +1,11 @@
 #include <RcppArmadillo.h>
 // [[Rcpp::depends(RcppArmadillo)]]
 
-// Placeholder C++ function for voxel-wise HRF estimation
-// This will be expanded in later sprints.
-
 // [[Rcpp::export]]
 arma::mat estimate_hrf_cpp(const arma::mat& X, const arma::mat& Y) {
-  arma::mat out(X.n_cols, Y.n_cols, arma::fill::zeros);
-  return out;
+  // Solve the multi-response linear model X * B = Y for B.
+  // This uses Armadillo's solve which will automatically
+  // choose the appropriate least squares solver when X is
+  // not square.
+  return arma::solve(X, Y);
 }


### PR DESCRIPTION
## Summary
- implement C++ solver for voxel-wise HRF estimation
- hook up `estimate_voxel_hrf` to use C++ results and store only HRF coefficients

## Testing
- `devtools::test()` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684af17627c8832dab5b86abccff597f